### PR TITLE
Removed isolated scope, use inherited scope values

### DIFF
--- a/app/src/js/confirmField.js
+++ b/app/src/js/confirmField.js
@@ -20,9 +20,6 @@ angular.module('ng.confirmField', [])
 .directive('ngConfirmField', function () {
   return {
     require: 'ngModel',
-    scope: {
-      confirmAgainst: '=',
-    },
     link: function (scope, iElement, iAttrs, ngModelCtrl) {
 
       var updateValidity = function () {
@@ -35,14 +32,21 @@ angular.module('ng.confirmField', [])
 
       // Test the confirm field view value matches the confirm against value.
       var isFieldValid = function () {
-        return ngModelCtrl.$viewValue === scope.confirmAgainst;
+        return ngModelCtrl.$viewValue === currentConfirmAgainstValue();
       };
+
+      function currentConfirmAgainstValue() {
+        return scope.$eval(iAttrs.confirmAgainst);
+      }
 
       // Convert data from view format to model format
       ngModelCtrl.$parsers.push(updateValidity);
 
       // Watch for changes in the confirmAgainst model.
       scope.$watch('confirmAgainst', updateValidity);
+      scope.$watch(function () {
+        return currentConfirmAgainstValue();
+      }, updateValidity);
     }
   };
 });


### PR DESCRIPTION
Isolated scope is not really needed, and if requested, can conflict with other directives:

```html
Error: [$compile:multidir] Multiple directives [ngConfirmField, popover] asking for
new/isolated scope on: <input id="confirmPassword" name="confirmPassword" type="password"
ng-model="user.confirmPassword" placeholder="Confirm" popover="{{(autofields
.confirmPassword.$valid) ? 'This field is valid' : ((autofields.confirmPassword.$error
.required? 'This field is required' : '')+(autofields.confirmPassword.$error.minlength?
'This is under minimum length' : ''))}}" ng-confirm-field="" confirm-against="user
.password" required="required" ng-minlength="6" class="form-control" popover-trigger
="focus" popover-placement="top">
```

Changed the code to read directly from parent scope with `scope.$eval`. Tests pass.